### PR TITLE
return non-zero error code upon failure; use cumcount to ensure compa…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         'click',
-        'covid_shared>=1.0.23',
+        'covid_shared>=1.0.40',
         'dill',
         'loguru',
         'matplotlib',

--- a/src/covid_model_deaths_spline/cli.py
+++ b/src/covid_model_deaths_spline/cli.py
@@ -57,9 +57,6 @@ def run_deaths(run_metadata,
     main = cli_tools.monitor_application(runner.make_deaths, logger, with_debugger)
     app_metadata, _ = main(inputs_root, run_directory, n_holdout_days, dow_holdouts, n_draws)
 
-    run_metadata['app_metadata'] = app_metadata.to_dict()
-    run_metadata.dump(run_directory / paths.METADATA_FILE_NAME)
-
-    cli_tools.make_links(app_metadata, run_directory, mark_dir_as_best, production_tag)
-
+    cli_tools.finish_application(run_metadata, app_metadata, run_directory,
+                                 mark_dir_as_best, production_tag)
     logger.info('**Done**')

--- a/src/covid_model_deaths_spline/data.py
+++ b/src/covid_model_deaths_spline/data.py
@@ -13,7 +13,7 @@ def evil_doings(full_data: pd.DataFrame) -> Tuple[pd.DataFrame, Dict]:
 #    arizona = full_data['location_id'] == 525
 #    full_data.loc[arizona, 'Hospitalizations'] = np.nan
 #    manipulation_metadata['arizona'] = 'dropped hospitalizations'
-    
+
 #    new_york = full_data['location_id'] == 555
 #    full_data.loc[new_york, 'Hospitalizations'] = np.nan
 #    manipulation_metadata['new_york'] = 'dropped hospitalizations'
@@ -34,7 +34,7 @@ def evil_doings(full_data: pd.DataFrame) -> Tuple[pd.DataFrame, Dict]:
     vietnam = full_data['location_id'] == 20
     full_data.loc[vietnam, 'Hospitalizations'] = np.nan
     manipulation_metadata['vietnam'] = 'dropped hospitalizations'
-   
+
     return full_data, manipulation_metadata
 
 
@@ -226,10 +226,7 @@ def fill_dates(df: pd.DataFrame, interp_var: str = None) -> pd.DataFrame:
 def drop_leading_zeros(df: pd.DataFrame, rate_vars: List[str], leading_window: int = 14) -> pd.DataFrame:
     zeros = df[rate_vars].sum(axis=1) == 0
     zeros_df = df.loc[zeros]
-    zeros_df['n'] = np.hstack(zeros_df
-                              .groupby('location_id', as_index=False)
-                              .apply(lambda x: x.reset_index().index.to_list())
-                              .to_list())
+    zeros_df['n'] = zeros_df.groupby('location_id').cumcount()
     zeros_df['max_n'] = zeros_df.groupby('location_id', as_index=False)['n'].transform(max)
     pre_month_zeros = zeros_df.loc[zeros_df['n'] <= zeros_df['max_n'] - leading_window].index
     df = df.drop(pre_month_zeros).reset_index(drop=True)


### PR DESCRIPTION
…tability with pandas 1.1.*

Jenkins was failing starting on the 3rd when develop was merged into master. That introduced data.drop_leading_zeros which had a groupby statement that failed with pandas 1.1.5 (which is currently the most recent pandas and therefore what jenkins uses). 

I've made 2 changes related to investigating this pipeline failure:

1. update data.drop_leading_zeros to use a method that is compatible with pandas 1.1.*
2. use cli_tools.finish_application so that run_deaths returns a non-zero exit code in case of failure (so jenkins doesn't think the pipeline succeeded)